### PR TITLE
🐛 fix(script): install `conan` package for Conan v2

### DIFF
--- a/cmake/targets/install_requirements.cmake
+++ b/cmake/targets/install_requirements.cmake
@@ -297,6 +297,60 @@ message("")
 restore_cmake_message_indent()
 
 
+if (VERSION MATCHES "^(2)$" OR
+    VERSION MATCHES "^(2)\\.([0-9]+)$")
+    message(STATUS "Running 'pip install' command to install the 'conan' package from sources...")
+    if (CMAKE_HOST_LINUX)
+        set(ENV_PATH                "${PROJ_CONDA_DIR}/bin:$ENV{PATH}")
+        set(ENV_LD_LIBRARY_PATH     "${PROJ_CONDA_DIR}/lib:$ENV{LD_LIBRARY_PATH}")
+        set(ENV_VARS_OF_SYSTEM      PATH=${ENV_PATH}
+                                    LD_LIBRARY_PATH=${ENV_LD_LIBRARY_PATH})
+    elseif (CMAKE_HOST_WIN32)
+        set(ENV_PATH                "${PROJ_CONDA_DIR}/bin"
+                                    "${PROJ_CONDA_DIR}/Scripts"
+                                    "${PROJ_CONDA_DIR}/Library/bin"
+                                    "${PROJ_CONDA_DIR}"
+                                    "$ENV{PATH}")
+        string(REPLACE ";" "\\\\;"  ENV_PATH "${ENV_PATH}")
+        set(ENV_VARS_OF_SYSTEM      PATH=${ENV_PATH})
+    else()
+        message(FATAL_ERROR "Invalid OS platform. (${CMAKE_HOST_SYSTEM_NAME})")
+    endif()
+    remove_cmake_message_indent()
+    message("")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env
+                ${ENV_VARS_OF_SYSTEM}
+                ${Python_EXECUTABLE} -m pip install
+                --editable .
+                --progress-bar=off
+                --verbose
+        WORKING_DIRECTORY ${PROJ_OUT_REPO_CONAN_DIR}
+        ECHO_OUTPUT_VARIABLE
+        ECHO_ERROR_VARIABLE
+        RESULT_VARIABLE RES_VAR
+        OUTPUT_VARIABLE OUT_VAR OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_VARIABLE  ERR_VAR ERROR_STRIP_TRAILING_WHITESPACE)
+    if (RES_VAR EQUAL 0)
+        if (ERR_VAR)
+            string(APPEND WARNING_REASON
+            "The command succeeded with warnings.\n\n"
+            "    result:\n\n${RES_VAR}\n\n"
+            "    stderr:\n\n${ERR_VAR}")
+            message("${WARNING_REASON}")
+        endif()
+    else()
+        string(APPEND FAILURE_REASON
+        "The command failed with fatal errors.\n"
+        "    result:\n${RES_VAR}\n"
+        "    stderr:\n${ERR_VAR}")
+        message(FATAL_ERROR "${FAILURE_REASON}")
+    endif()
+    message("")
+    restore_cmake_message_indent()
+endif()
+
+
 find_package(Sphinx     MODULE REQUIRED)
 
 


### PR DESCRIPTION
Fix: #66 

Installed the `conan` package from sources for Conan v2 to fix the errors occurring in the following workflow:

https://github.com/localizethedocs/conan-docs-l10n/actions/runs/17729112377