### PR TITLE
🐛 fix(workflow): update default version input

### DIFF
--- a/.github/workflows/ci-check-pr-status.yml
+++ b/.github/workflows/ci-check-pr-status.yml
@@ -129,7 +129,7 @@ jobs:
       ENABLE: ${{ needs.before-check.outputs.SCRIPT_CHANGE == 'true' }}
       RUNNER: ${{ vars.RUNNER }}
       CHECKOUT: ${{ github.ref }}
-      VERSION: 'master'
+      VERSION: '2'
       LANGUAGE: 'zh_TW'
       MODE_OF_UPDATE: 'COMPARE'
       BASEURL_HREF: ${{ vars.BASEURL_HREF }}

--- a/.github/workflows/ci-gettext-statistics.yml
+++ b/.github/workflows/ci-gettext-statistics.yml
@@ -28,7 +28,7 @@ on:
         description: 'VERSION_GROUP input (for group mode)'
         required: true
         type: choice
-        default: 'v1'
+        default: 'v2'
         options:
           - 'v1'
           - 'v2'


### PR DESCRIPTION
- Changed default version from 'v1' to 'v2' in ci-gettext-statistics.yml.
- Updated version input in ci-check-pr-status.yml from 'master' to '2'.