### PR TITLE
✨ feat(workflow): use crowdin-update-readme workflow

### DIFF
--- a/.github/workflows/ci-check-pr-status.yml
+++ b/.github/workflows/ci-check-pr-status.yml
@@ -49,6 +49,7 @@ jobs:
           echo "vars.ACTOR_NAME = ${{ vars.ACTOR_NAME }}"
           echo "vars.ACTOR_EMAIL = ${{ vars.ACTOR_EMAIL }}"
           echo "vars.CROWDIN_PROJECT_ID = ${{ vars.CROWDIN_PROJECT_ID }}"
+          echo "vars.CROWDIN_README_ID = ${{ vars.CROWDIN_README_ID }}"
           echo "vars.CROWDIN_BASE_URL = ${{ vars.CROWDIN_BASE_URL }}"
           echo "vars.GPG_FINGERPRINT = ${{ vars.GPG_FINGERPRINT }}"
           echo "[Secrets]"
@@ -87,7 +88,7 @@ jobs:
           echo "steps.filter.outputs.document_count = ${{ steps.filter.outputs.document_count }}"
           echo "steps.filter.outputs.script_count   = ${{ steps.filter.outputs.script_count }}"
 
-  check-crowdin-update-docs:
+  check-crowdin-update-readme:
     needs: [ 'before-check' ]
     if: ${{ ( github.repository == 'localizethedocs/conan-docs-l10n' ) &&
             ( ( github.event_name   == 'pull_request' ) &&
@@ -96,17 +97,17 @@ jobs:
               ( github.event.action == 'opened' ||
                 github.event.action == 'synchronize' ||
                 github.event.action == 'reopened' ) ) }}
-    uses: localizethedocs/ci-common/.github/workflows/use-crowdin-update-docs.yml@main
+    uses: localizethedocs/ci-common/.github/workflows/use-crowdin-update-readme.yml@main
     with:
       ENABLE: ${{ needs.before-check.outputs.DOCUMENT_CHANGE == 'true' }}
       RUNNER: ${{ vars.RUNNER }}
       CHECKOUT: ${{ github.ref }}
-      VERSION: 'check'
       LANGUAGE: 'zh_TW'
       LANGUAGE_SOURCE: 'en_US'
       ACTOR_NAME: ${{ vars.ACTOR_NAME }}
       ACTOR_EMAIL: ${{ vars.ACTOR_EMAIL }}
-      CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+      CROWDIN_BRANCH_NAME: 'check-pr-conan-docs-l10n'
+      CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_README_ID }}
       CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
       GPG_FINGERPRINT: ${{ vars.GPG_FINGERPRINT }}
     secrets:

--- a/.github/workflows/ci-crowdin-update-readme.yml
+++ b/.github/workflows/ci-crowdin-update-readme.yml
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved BSD 3-Clause License.
 # See accompanying file LICENSE-BSD for details.
 
-name: ci-crowdin-update-docs
+name: ci-crowdin-update-readme
 
 on:
   # Triggers the workflow when README changes are pushed to the 'main' branch.
@@ -47,7 +47,7 @@ jobs:
           echo "vars.RUNNER = ${{ vars.RUNNER }}"
           echo "vars.ACTOR_NAME = ${{ vars.ACTOR_NAME }}"
           echo "vars.ACTOR_EMAIL = ${{ vars.ACTOR_EMAIL }}"
-          echo "vars.CROWDIN_PROJECT_ID = ${{ vars.CROWDIN_PROJECT_ID }}"
+          echo "vars.CROWDIN_README_ID = ${{ vars.CROWDIN_README_ID }}"
           echo "vars.CROWDIN_BASE_URL = ${{ vars.CROWDIN_BASE_URL }}"
           echo "vars.GPG_FINGERPRINT = ${{ vars.GPG_FINGERPRINT }}"
           echo "[Secrets]"
@@ -71,8 +71,8 @@ jobs:
             echo "vars.ACTOR_EMAIL is missing."
             REQUIRED_VARIABLES_EXIST=false
           fi
-          if [[ -z "${{ vars.CROWDIN_PROJECT_ID }}" ]]; then
-            echo "vars.CROWDIN_PROJECT_ID is missing."
+          if [[ -z "${{ vars.CROWDIN_README_ID }}" ]]; then
+            echo "vars.CROWDIN_README_ID is missing."
             REQUIRED_VARIABLES_EXIST=false
           fi
           if [[ -z "${{ vars.CROWDIN_BASE_URL }}" ]]; then
@@ -121,17 +121,17 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: true
-    uses: localizethedocs/ci-common/.github/workflows/use-crowdin-update-docs.yml@main
+    uses: localizethedocs/ci-common/.github/workflows/use-crowdin-update-readme.yml@main
     with:
       ENABLE: true
       RUNNER: ${{ vars.RUNNER }}
       CHECKOUT: ${{ github.ref }}
-      VERSION: 'docs'
       LANGUAGE: ${{ inputs.LANGUAGE || 'all' }}
       LANGUAGE_SOURCE: 'en_US'
       ACTOR_NAME: ${{ vars.ACTOR_NAME }}
       ACTOR_EMAIL: ${{ vars.ACTOR_EMAIL }}
-      CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+      CROWDIN_BRANCH_NAME: 'conan-docs-l10n'
+      CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_README_ID }}
       CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
       GPG_FINGERPRINT: ${{ vars.GPG_FINGERPRINT }}
     secrets:

--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ The goal of this project is to translate the Conan Documentation into multiple l
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/conan-docs-l10n/actions/workflows/ci-crowdin-update-docs.yml"><img alt="ci-crowdin-update-docs" src="https://github.com/localizethedocs/conan-docs-l10n/actions/workflows/ci-crowdin-update-docs.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/conan-docs-l10n/actions/workflows/ci-crowdin-update-readme.yml"><img alt="ci-crowdin-update-readme" src="https://github.com/localizethedocs/conan-docs-l10n/actions/workflows/ci-crowdin-update-readme.yml/badge.svg" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
-        <div>Update <code>docs</code> translations by Crowdin CLI tool.</div>
+        <div>Update README translations by Crowdin CLI tool.</div>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
- Use `crowdin-update-readme` workflow for README translations.
- Use `crowdin-update-readme` workflow for PR checking.
- Display the status of the new workflow in `README.md`.

Synced from: https://github.com/localizethedocs/cmake-docs-l10n/commit/cd77f87b05deff2d6a2276ad9dd5bb2056d7de00