### PR TITLE
📝 docs(readme): remove personal sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@
   <li><a href="#preview-translations">Preview Translations</a></li>
   <li><a href="#maintainers">Maintainers</a></li>
   <li><a href="#support-this-project">Support this Project</a></li>
-  <li><a href="#sponsorship">Sponsorship</a></li>
+  <li><a href="#financial-sponsors">Financial Sponsors</a></li>
   <li><a href="#code-contributors">Code Contributors</a></li>
   <li><a href="#translation-contributors">Translation Contributors</a></li>
-  <li><a href="#financial-contributors">Financial Contributors</a></li>
   <li><a href="#licenses">Licenses</a></li>
 </ul>
 
@@ -422,12 +421,12 @@ You can contribute and support this project by doing any of the following:
   <li>Submit issues on <a href="https://github.com/localizethedocs/conan-docs-l10n/issues">GitHub</a> if you found any bug.</li>
   <li>Submit pull requests on <a href="https://github.com/localizethedocs/conan-docs-l10n/pulls">GitHub</a> if you know how to fix the bug.</li>
   <li>Contribute your translations on <a href="https://localizethedocs.crowdin.com/conan-docs-l10n">Crowdin</a>.</li>
-  <li>If you love this kind of l10n projects, please consider <a href="#sponsorship">sponsorship</a>.</li>
+  <li>Consider becoming a <a href="#financial-sponsors">sponsor</a> if you love this kind of l10n projects.</li>
 </ul>
 
 It will facilitate the creation and ongoing maintenance of l10n projects for open-source documentation.
 
-<h2 id="sponsorship"><a href="#table-of-contents">Sponsorship</a></h2>
+<h2 id="financial-sponsors"><a href="#table-of-contents">Financial Sponsors</a></h2>
 
 You can sponsor the projects through the following platforms:
 
@@ -456,34 +455,10 @@ You can sponsor the projects through the following platforms:
 </table>
 </div>
 
-Alternatively, you can sponsor the maintainers directly through the following platforms:
+Maintenance of the projects is made possible by the generous support of our sponsors:
 
 <div align="center">
-<table>
-  <tbody>
-    <tr>
-      <th rowspan="1" colspan="2" align="center" style="text-align: center; width: 100%;"><div>Haowei Hsu</div></th>
-    </tr>
-    <!-- Row 1 -->
-    <tr>
-      <th rowspan="1" colspan="1" align="center" style="text-align: center; width: 50%;"><div>Patreon</div></th>
-      <th rowspan="1" colspan="1" align="center" style="text-align: center; width: 50%;"><div>Afdian</div></th>
-    </tr>
-    <!-- Row 2 -->
-    <tr>
-      <td rowspan="1" colspan="1" align="center" style="text-align: center; width: 50%;" >
-        <div><a href="https://www.patreon.com/hwhsu1231" target="_blank">
-          <img width="200" src="https://cdn.jsdelivr.net/gh/localizethedocs/static/button/sponsor-patreon.png" alt="Patreon" />
-        </a></div>
-      </td>
-      <td rowspan="1" colspan="1" align="center" style="text-align: center; width: 50%;">
-        <div><a href="https://www.afdian.com/a/hwhsu1231" target="_blank">
-          <img width="200" src="https://cdn.jsdelivr.net/gh/localizethedocs/static/button/sponsor-afdian.png" alt="Afdian" />
-        </a></div>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<img width="100%" alt="Localize The Docs" src="https://cdn.jsdelivr.net/gh/localizethedocs/sponsors/static/sponsors.svg" />
 </div>
 
 <h2 id="code-contributors"><a href="#table-of-contents">Code Contributors</a></h2>
@@ -496,24 +471,6 @@ Alternatively, you can sponsor the maintainers directly through the following pl
 
 <div align="center">
 <img width="100%" alt="Crowdin Contributors SVG" src="https://cdn.jsdelivr.net/gh/localizethedocs/conan-docs-l10n@static/crowdin-contributors.svg">
-</div>
-
-<h2 id="financial-contributors"><a href="#table-of-contents">Financial Contributors</a></h2>
-
-<div align="center">
-<h3 id="localize-the-docs">Localize The Docs</h3>
-</div>
-
-<div align="center">
-<img width="100%" alt="Localize The Docs" src="https://cdn.jsdelivr.net/gh/localizethedocs/sponsors/static/sponsors.svg" />
-</div>
-
-<div align="center">
-<h3 id="haowei-hsu">Haowei Hsu</h3>
-</div>
-
-<div align="center">
-<img width="100%" alt="Haowei Hsu" src="https://cdn.jsdelivr.net/gh/hwhsu1231/sponsors/static/sponsors.svg" />
 </div>
 
 <h2 id="licenses"><a href="#table-of-contents">Licenses</a></h2>


### PR DESCRIPTION
- Remove personal sponsorship option.
- Rename Financial Contributors section to Financial Sponsors.
- Merge Sponsorship section with Financial Sponsors section.

Synced from: https://github.com/localizethedocs/cmake-docs-l10n/commit/2a7a64de973e30e1296cecde19de60ed9baf2730